### PR TITLE
Build React Supabase foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - 'codex/**'
+
+jobs:
+  app:
+    name: Install, lint, and build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.env
+.env.*
+!.env.example
+*.tsbuildinfo
+.codex-tools

--- a/codex/CODEX_START_HERE.md
+++ b/codex/CODEX_START_HERE.md
@@ -29,6 +29,7 @@ Do not commit real keys. When env values are missing, the app uses mock fallback
 - `src/pages/ExecutiveCommandCenter.tsx` is the first screen.
 - `src/pages/SewingControlRoom.tsx` is the second screen.
 - `src/App.tsx` connects both screens through one working shell, not disconnected pages.
+- `.github/workflows/ci.yml` runs install, lint, and build for pushes and pull requests.
 
 ## Data Notes
 
@@ -37,6 +38,7 @@ Do not commit real keys. When env values are missing, the app uses mock fallback
 - `G-14` is preserved as the corrected line code.
 - `G-11` is ghost/non-working.
 - Historical events belong in `audit_events` with JSON snapshots in `old_values` and `new_values`.
+- `supabase/migrations/003_authenticated_development_rls_policies.sql` contains V1 authenticated development RLS policies. These are intentionally broad for foundation work and must be tightened before production exposure.
 
 ## Commands
 

--- a/codex/CODEX_START_HERE.md
+++ b/codex/CODEX_START_HERE.md
@@ -1,0 +1,46 @@
+# Codex Start Here
+
+## Scope
+
+This repo is the first working React + TypeScript + Supabase foundation for the Jade Textile Factory System.
+
+Follow GitHub issue #1 exactly:
+
+- Do not invent database tables.
+- Use Supabase project `mhfheswzjrdoqgbygjfc` as the source of truth.
+- Keep order, customer, style, PO, line, group, and shipment date connected across modules.
+- Keep factory formulas centralized in `src/lib/factoryFormulas.ts`.
+- Keep line status and risk rules centralized in `src/lib/riskRules.ts`.
+- Keep the Supabase client isolated in `src/lib/supabase.ts`.
+
+## Supabase
+
+Frontend env names:
+
+```bash
+VITE_SUPABASE_URL=
+VITE_SUPABASE_PUBLISHABLE_KEY=
+```
+
+Do not commit real keys. When env values are missing, the app uses mock fallback data. When env values exist, the app queries the existing Supabase tables and does not use fallback rows.
+
+## Screens
+
+- `src/pages/ExecutiveCommandCenter.tsx` is the first screen.
+- `src/pages/SewingControlRoom.tsx` is the second screen.
+- `src/App.tsx` connects both screens through one working shell, not disconnected pages.
+
+## Data Notes
+
+- Sewing layout is generated from `factory_lines` and `line_current_assignments`.
+- `H93/115` is normalized to `H93`; do not create fake `H115`.
+- `G-14` is preserved as the corrected line code.
+- `G-11` is ghost/non-working.
+- Historical events belong in `audit_events` with JSON snapshots in `old_values` and `new_values`.
+
+## Commands
+
+```bash
+npm install
+npm run build
+```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,18 @@
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    ignores: ['dist', 'node_modules', '.codex-tools'],
+  },
+  ...tseslint.configs.recommended,
+  {
+    files: ['src/**/*.ts', 'src/**/*.tsx', 'vite.config.ts'],
+    languageOptions: {
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+  },
+);

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="ar" dir="rtl">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/package.json
+++ b/package.json
@@ -1,1 +1,28 @@
-{"scripts":{"dev":"vite","build":"tsc -b && vite build","preview":"vite preview","lint":"eslint ."},"dependencies":{"@supabase/supabase-js":"^2.48.0","@vitejs/plugin-react":"^4.3.4","vite":"^6.0.0","typescript":"^5.7.0","react":"^19.0.0","react-dom":"^19.0.0","lucide-react":"^0.468.0"},"devDependencies":{"eslint":"^9.17.0","typescript-eslint":"^8.18.0","@types/react":"^19.0.0","@types/react-dom":"^19.0.0"}}
+{
+  "name": "jade-textile-factory-system",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.48.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "lucide-react": "^0.468.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "eslint": "^9.17.0",
+    "typescript-eslint": "^8.18.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,83 @@
+import { Activity, Factory, LayoutDashboard, RadioTower } from 'lucide-react';
+import { useState } from 'react';
+import ExecutiveCommandCenter from './pages/ExecutiveCommandCenter';
+import SewingControlRoom from './pages/SewingControlRoom';
+
+type ViewKey = 'executive' | 'sewing';
+
+const views: Array<{
+  key: ViewKey;
+  label: string;
+  caption: string;
+  icon: typeof LayoutDashboard;
+}> = [
+  {
+    key: 'executive',
+    label: 'Executive Command Center',
+    caption: 'Orders, risk, flow, and management actions',
+    icon: LayoutDashboard,
+  },
+  {
+    key: 'sewing',
+    label: 'Sewing Control Room',
+    caption: 'Live line layout from factory assignments',
+    icon: Factory,
+  },
+];
+
+export default function App() {
+  const [activeView, setActiveView] = useState<ViewKey>('executive');
+  const ActivePage = activeView === 'executive' ? ExecutiveCommandCenter : SewingControlRoom;
+
+  return (
+    <div className="app-shell" dir="rtl">
+      <aside className="sidebar" aria-label="Primary navigation">
+        <div className="brand-block">
+          <div className="brand-mark">
+            <Activity size={22} strokeWidth={2.4} />
+          </div>
+          <div>
+            <p className="eyebrow">Jade Textile</p>
+            <h1>Factory System</h1>
+          </div>
+        </div>
+
+        <nav className="view-tabs" role="tablist" aria-label="Factory modules">
+          {views.map((view) => {
+            const Icon = view.icon;
+            const isActive = activeView === view.key;
+
+            return (
+              <button
+                key={view.key}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                className={isActive ? 'view-tab active' : 'view-tab'}
+                onClick={() => setActiveView(view.key)}
+              >
+                <Icon size={18} />
+                <span>
+                  <strong>{view.label}</strong>
+                  <small>{view.caption}</small>
+                </span>
+              </button>
+            );
+          })}
+        </nav>
+
+        <div className="sidebar-status">
+          <RadioTower size={18} />
+          <span>
+            <strong>Arabic-first workflow</strong>
+            <small>AR now - EN/TR ready</small>
+          </span>
+        </div>
+      </aside>
+
+      <main className="workspace">
+        <ActivePage />
+      </main>
+    </div>
+  );
+}

--- a/src/components/FactoryFlowRibbon.tsx
+++ b/src/components/FactoryFlowRibbon.tsx
@@ -1,0 +1,33 @@
+type FlowStage = {
+  label: string;
+  activeOrders: number;
+  blockedOrders: number;
+};
+
+type FactoryFlowRibbonProps = {
+  stages: FlowStage[];
+};
+
+export default function FactoryFlowRibbon({ stages }: FactoryFlowRibbonProps) {
+  return (
+    <div className="flow-ribbon" aria-label="Factory flow ribbon">
+      {stages.map((stage, index) => {
+        const hasBlock = stage.blockedOrders > 0;
+        const isActive = stage.activeOrders > 0;
+
+        return (
+          <div
+            key={stage.label}
+            className={`flow-stage ${hasBlock ? 'blocked' : ''} ${isActive ? 'live' : ''}`}
+          >
+            <span className="flow-index">{String(index + 1).padStart(2, '0')}</span>
+            <strong>{stage.label}</strong>
+            <small>
+              {stage.activeOrders} active - {stage.blockedOrders} blocked
+            </small>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/KpiCard.tsx
+++ b/src/components/KpiCard.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react';
+
+type KpiCardProps = {
+  label: string;
+  value: string;
+  detail: string;
+  tone?: 'green' | 'amber' | 'red' | 'blue' | 'gray';
+  icon: ReactNode;
+};
+
+export default function KpiCard({ label, value, detail, tone = 'gray', icon }: KpiCardProps) {
+  return (
+    <article className={`kpi-card tone-${tone}`}>
+      <div className="kpi-icon" aria-hidden="true">
+        {icon}
+      </div>
+      <div>
+        <p>{label}</p>
+        <strong>{value}</strong>
+        <span>{detail}</span>
+      </div>
+    </article>
+  );
+}

--- a/src/components/LineTile.tsx
+++ b/src/components/LineTile.tsx
@@ -1,0 +1,63 @@
+import { Clock3, Users } from 'lucide-react';
+import { productionAchievementPercent, roundMetric } from '../lib/factoryFormulas';
+import { isGhostLine, normalizeLineStatus, statusTone } from '../lib/riskRules';
+
+export type LineTileData = {
+  lineCode: string;
+  group: string;
+  customer: string;
+  style: string;
+  po: string;
+  shipmentDate: string;
+  status: string;
+  target: number;
+  actual: number;
+  manpower: number;
+  activeDowntime: string;
+  isActive: boolean;
+  notes?: string;
+};
+
+type LineTileProps = {
+  line: LineTileData;
+};
+
+export default function LineTile({ line }: LineTileProps) {
+  const normalizedStatus = normalizeLineStatus(line.status);
+  const tone = isGhostLine(line.lineCode) || !line.isActive ? 'gray' : statusTone[normalizedStatus];
+  const achievement = productionAchievementPercent(line.actual, line.target);
+
+  return (
+    <article className={`line-tile tone-${tone}`}>
+      <header>
+        <div>
+          <strong>{line.lineCode}</strong>
+          <span>{line.group}</span>
+        </div>
+        <em>{isGhostLine(line.lineCode) ? 'ghost' : normalizedStatus}</em>
+      </header>
+
+      <div className="line-order">
+        <span>{line.customer}</span>
+        <strong>{line.style}</strong>
+        <small>PO {line.po} - Ship {line.shipmentDate}</small>
+      </div>
+
+      <div className="line-meter" aria-label={`Production achievement ${roundMetric(achievement)} percent`}>
+        <span style={{ inlineSize: `${Math.min(100, achievement)}%` }} />
+      </div>
+
+      <footer>
+        <span>
+          <Clock3 size={15} />
+          {line.actual}/{line.target}
+        </span>
+        <span>
+          <Users size={15} />
+          {line.manpower}
+        </span>
+        <span>{line.activeDowntime}</span>
+      </footer>
+    </article>
+  );
+}

--- a/src/components/LineTile.tsx
+++ b/src/components/LineTile.tsx
@@ -1,6 +1,6 @@
 import { Clock3, Users } from 'lucide-react';
 import { productionAchievementPercent, roundMetric } from '../lib/factoryFormulas';
-import { isGhostLine, normalizeLineStatus, statusTone } from '../lib/riskRules';
+import { normalizeLineStatus, statusTone } from '../lib/riskRules';
 
 export type LineTileData = {
   lineCode: string;
@@ -15,6 +15,7 @@ export type LineTileData = {
   manpower: number;
   activeDowntime: string;
   isActive: boolean;
+  isGhost: boolean;
   notes?: string;
 };
 
@@ -24,7 +25,7 @@ type LineTileProps = {
 
 export default function LineTile({ line }: LineTileProps) {
   const normalizedStatus = normalizeLineStatus(line.status);
-  const tone = isGhostLine(line.lineCode) || !line.isActive ? 'gray' : statusTone[normalizedStatus];
+  const tone = line.isGhost || !line.isActive ? 'gray' : statusTone[normalizedStatus];
   const achievement = productionAchievementPercent(line.actual, line.target);
 
   return (
@@ -34,7 +35,7 @@ export default function LineTile({ line }: LineTileProps) {
           <strong>{line.lineCode}</strong>
           <span>{line.group}</span>
         </div>
-        <em>{isGhostLine(line.lineCode) ? 'ghost' : normalizedStatus}</em>
+        <em>{line.isGhost ? 'ghost' : normalizedStatus}</em>
       </header>
 
       <div className="line-order">

--- a/src/lib/factoryFormulas.ts
+++ b/src/lib/factoryFormulas.ts
@@ -1,0 +1,95 @@
+const toFiniteNumber = (value: number) => (Number.isFinite(value) ? value : 0);
+
+export const normalizeEfficiency = (efficiency: number) => {
+  const value = toFiniteNumber(efficiency);
+  return value > 1 ? value / 100 : value;
+};
+
+export const availableMinutes = (operators: number, workingMinutes: number) =>
+  Math.max(0, toFiniteNumber(operators)) * Math.max(0, toFiniteNumber(workingMinutes));
+
+export const earnedMinutes = (outputQuantity: number, smv: number) =>
+  Math.max(0, toFiniteNumber(outputQuantity)) * Math.max(0, toFiniteNumber(smv));
+
+export const efficiencyPercent = (earned: number, available: number) => {
+  const safeAvailable = Math.max(0, toFiniteNumber(available));
+  if (safeAvailable === 0) {
+    return 0;
+  }
+
+  return (Math.max(0, toFiniteNumber(earned)) / safeAvailable) * 100;
+};
+
+export const dailyLineCapacity = (
+  operators: number,
+  workingMinutes: number,
+  efficiency: number,
+  smv: number,
+) => {
+  const safeSmv = Math.max(0, toFiniteNumber(smv));
+  if (safeSmv === 0) {
+    return 0;
+  }
+
+  return (availableMinutes(operators, workingMinutes) * normalizeEfficiency(efficiency)) / safeSmv;
+};
+
+export const requiredProductionDays = (balanceQuantity: number, dailyCapacity: number) => {
+  const safeCapacity = Math.max(0, toFiniteNumber(dailyCapacity));
+  if (safeCapacity === 0) {
+    return 0;
+  }
+
+  return Math.max(0, toFiniteNumber(balanceQuantity)) / safeCapacity;
+};
+
+export const requiredOperators = (
+  targetQuantity: number,
+  smv: number,
+  workingMinutes: number,
+  efficiency: number,
+) => {
+  const safeWorkingMinutes = Math.max(0, toFiniteNumber(workingMinutes));
+  const safeEfficiency = normalizeEfficiency(efficiency);
+  if (safeWorkingMinutes === 0 || safeEfficiency === 0) {
+    return 0;
+  }
+
+  return (
+    (Math.max(0, toFiniteNumber(targetQuantity)) * Math.max(0, toFiniteNumber(smv))) /
+    safeWorkingMinutes /
+    safeEfficiency
+  );
+};
+
+export const materialReadinessPercent = (receivedQuantity: number, requiredQuantity: number) => {
+  const safeRequired = Math.max(0, toFiniteNumber(requiredQuantity));
+  if (safeRequired === 0) {
+    return 0;
+  }
+
+  return (Math.max(0, toFiniteNumber(receivedQuantity)) / safeRequired) * 100;
+};
+
+export const dhu = (defectQuantity: number, checkedQuantity: number) => {
+  const safeChecked = Math.max(0, toFiniteNumber(checkedQuantity));
+  if (safeChecked === 0) {
+    return 0;
+  }
+
+  return (Math.max(0, toFiniteNumber(defectQuantity)) / safeChecked) * 100;
+};
+
+export const productionAchievementPercent = (actualQuantity: number, targetQuantity: number) => {
+  const safeTarget = Math.max(0, toFiniteNumber(targetQuantity));
+  if (safeTarget === 0) {
+    return 0;
+  }
+
+  return (Math.max(0, toFiniteNumber(actualQuantity)) / safeTarget) * 100;
+};
+
+export const roundMetric = (value: number, digits = 1) => {
+  const multiplier = 10 ** digits;
+  return Math.round(toFiniteNumber(value) * multiplier) / multiplier;
+};

--- a/src/lib/riskRules.ts
+++ b/src/lib/riskRules.ts
@@ -1,0 +1,77 @@
+export type LineStatus = 'running' | 'warning' | 'stopped' | 'blocked' | 'changeover' | 'idle';
+export type RiskLevel = 'green' | 'amber' | 'red' | 'critical' | 'high' | 'medium' | 'low' | 'not_assessed';
+
+export const statusTone: Record<LineStatus, 'green' | 'amber' | 'red' | 'blue' | 'gray'> = {
+  running: 'green',
+  warning: 'amber',
+  stopped: 'red',
+  blocked: 'red',
+  changeover: 'blue',
+  idle: 'gray',
+};
+
+export const normalizeLineStatus = (status?: string | null): LineStatus => {
+  if (status === 'running' || status === 'warning' || status === 'stopped' || status === 'changeover') {
+    return status;
+  }
+
+  if (status === 'blocked') {
+    return 'blocked';
+  }
+
+  return 'idle';
+};
+
+export const normalizeLineCode = (lineCode: string) => {
+  const compact = lineCode.trim().toUpperCase();
+
+  if (compact === 'H93/115' || compact === 'H93-115' || compact === 'H93 115') {
+    return 'H93';
+  }
+
+  if (compact === 'G14') {
+    return 'G-14';
+  }
+
+  return compact;
+};
+
+export const isGhostLine = (lineCode: string) => normalizeLineCode(lineCode) === 'G-11';
+
+export const riskTone = (risk?: string | null) => {
+  if (risk === 'critical' || risk === 'high' || risk === 'red') {
+    return 'red';
+  }
+
+  if (risk === 'amber' || risk === 'medium') {
+    return 'amber';
+  }
+
+  if (risk === 'green' || risk === 'low') {
+    return 'green';
+  }
+
+  return 'gray';
+};
+
+export const shipmentRisk = (shipmentDate?: string | null) => {
+  if (!shipmentDate) {
+    return 'not_assessed' satisfies RiskLevel;
+  }
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const shipDate = new Date(`${shipmentDate}T00:00:00`);
+  const daysRemaining = Math.ceil((shipDate.getTime() - today.getTime()) / 86_400_000);
+
+  if (daysRemaining < 0) {
+    return 'red' satisfies RiskLevel;
+  }
+
+  if (daysRemaining <= 2) {
+    return 'amber' satisfies RiskLevel;
+  }
+
+  return 'green' satisfies RiskLevel;
+};

--- a/src/lib/riskRules.ts
+++ b/src/lib/riskRules.ts
@@ -36,7 +36,48 @@ export const normalizeLineCode = (lineCode: string) => {
   return compact;
 };
 
+export const normalizeGroupCode = (value?: string | null) => {
+  if (!value) {
+    return '';
+  }
+
+  const compact = value.trim().toUpperCase().replace(/\s+/g, '');
+  if (compact === 'G11') {
+    return 'G-11';
+  }
+  if (compact === 'G14') {
+    return 'G-14';
+  }
+
+  return value.trim().toUpperCase();
+};
+
 export const isGhostLine = (lineCode: string) => normalizeLineCode(lineCode) === 'G-11';
+
+export const isGhostOrNonWorkingLine = (params: {
+  lineCode?: string | null;
+  groupCode?: string | null;
+  zone?: string | null;
+  lineType?: string | null;
+  isActive?: boolean | null;
+  isCoreProduction?: boolean | null;
+}) => {
+  const lineCode = params.lineCode ? normalizeLineCode(params.lineCode) : '';
+  const groupCode = normalizeGroupCode(params.groupCode);
+  const zone = normalizeGroupCode(params.zone);
+  const lineType = params.lineType?.trim().toLowerCase() ?? '';
+
+  return (
+    lineCode === 'G-11' ||
+    groupCode === 'G-11' ||
+    zone === 'G-11' ||
+    lineType === 'ghost' ||
+    lineType === 'non_working' ||
+    lineType === 'non-working' ||
+    params.isActive === false ||
+    params.isCoreProduction === false
+  );
+};
 
 export const riskTone = (risk?: string | null) => {
   if (risk === 'critical' || risk === 'high' || risk === 'red') {

--- a/src/lib/riskRules.ts
+++ b/src/lib/riskRules.ts
@@ -36,48 +36,49 @@ export const normalizeLineCode = (lineCode: string) => {
   return compact;
 };
 
-export const normalizeGroupCode = (value?: string | null) => {
-  if (!value) {
-    return '';
-  }
-
-  const compact = value.trim().toUpperCase().replace(/\s+/g, '');
-  if (compact === 'G11') {
-    return 'G-11';
-  }
-  if (compact === 'G14') {
-    return 'G-14';
-  }
-
-  return value.trim().toUpperCase();
-};
-
 export const isGhostLine = (lineCode: string) => normalizeLineCode(lineCode) === 'G-11';
 
-export const isGhostOrNonWorkingLine = (params: {
-  lineCode?: string | null;
+type GhostProductionAreaInput = {
+  lineCode: string;
   groupCode?: string | null;
+  groupName?: string | null;
   zone?: string | null;
   lineType?: string | null;
-  isActive?: boolean | null;
-  isCoreProduction?: boolean | null;
-}) => {
-  const lineCode = params.lineCode ? normalizeLineCode(params.lineCode) : '';
-  const groupCode = normalizeGroupCode(params.groupCode);
-  const zone = normalizeGroupCode(params.zone);
-  const lineType = params.lineType?.trim().toLowerCase() ?? '';
+  isActive: boolean;
+  isCoreProduction: boolean;
+};
 
+const hasGhostMarker = (value?: string | null) => {
+  if (!value) {
+    return false;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  const compactAreaCode = normalized.replace(/[-_\s]/g, '');
   return (
-    lineCode === 'G-11' ||
-    groupCode === 'G-11' ||
-    zone === 'G-11' ||
-    lineType === 'ghost' ||
-    lineType === 'non_working' ||
-    lineType === 'non-working' ||
-    params.isActive === false ||
-    params.isCoreProduction === false
+    compactAreaCode === 'g11' ||
+    normalized === 'ghost' ||
+    normalized.includes('ghost') ||
+    /non[-_\s]?working/.test(normalized)
   );
 };
+
+export const isGhostProductionArea = ({
+  lineCode,
+  groupCode,
+  groupName,
+  zone,
+  lineType,
+  isActive,
+  isCoreProduction,
+}: GhostProductionAreaInput) =>
+  isGhostLine(lineCode) ||
+  hasGhostMarker(groupCode) ||
+  hasGhostMarker(groupName) ||
+  hasGhostMarker(zone) ||
+  hasGhostMarker(lineType) ||
+  !isActive ||
+  !isCoreProduction;
 
 export const riskTone = (risk?: string | null) => {
   if (risk === 'critical' || risk === 'high' || risk === 'red') {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,13 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '../types/database';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const supabasePublishableKey = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY as string | undefined;
+
+export const isSupabaseConfigured = Boolean(supabaseUrl && supabasePublishableKey);
+
+export const supabase: SupabaseClient<Database> | null = isSupabaseConfigured
+  ? createClient<Database>(supabaseUrl as string, supabasePublishableKey as string)
+  : null;
+
+export const supabaseProjectUrl = supabaseUrl ?? 'https://mhfheswzjrdoqgbygjfc.supabase.co';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './styles/app.css';
+
+createRoot(document.getElementById('root') as HTMLElement).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/src/pages/ExecutiveCommandCenter.tsx
+++ b/src/pages/ExecutiveCommandCenter.tsx
@@ -1,0 +1,382 @@
+import {
+  AlertTriangle,
+  Boxes,
+  CalendarClock,
+  Factory,
+  Gauge,
+  ListChecks,
+  PackageSearch,
+  ShieldAlert,
+  Target,
+} from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import FactoryFlowRibbon from '../components/FactoryFlowRibbon';
+import KpiCard from '../components/KpiCard';
+import { productionAchievementPercent, roundMetric } from '../lib/factoryFormulas';
+import { riskTone } from '../lib/riskRules';
+import { isSupabaseConfigured, supabase } from '../lib/supabase';
+import type { Tables } from '../types/database';
+
+type OrderRow = Pick<
+  Tables<'orders'>,
+  'id' | 'order_code' | 'status' | 'risk_level' | 'shipment_date' | 'current_stage'
+>;
+type MaterialRow = Pick<Tables<'material_readiness'>, 'shortage_risk' | 'readiness_percent'>;
+type HourlyRow = Pick<Tables<'hourly_production'>, 'target_qty' | 'output_qty'>;
+type StageRow = Pick<Tables<'production_stage_records'>, 'stage_name' | 'status' | 'risk_level'>;
+type SnapshotRow = Tables<'factory_snapshots'>;
+type ActionRow = Pick<
+  Tables<'management_actions'>,
+  'id' | 'issue' | 'risk_level' | 'responsible_team' | 'required_decision' | 'due_date' | 'status'
+>;
+
+type DashboardData = {
+  orders: OrderRow[];
+  materials: MaterialRow[];
+  hourly: HourlyRow[];
+  stages: StageRow[];
+  snapshot: SnapshotRow | null;
+  actions: ActionRow[];
+  source: 'supabase' | 'mock';
+};
+
+const flowLabels = [
+  'Order',
+  'Pre-Stock',
+  'Planning',
+  'Cutting',
+  'Printing',
+  'Embroidery',
+  'Sewing',
+  'Finishing',
+  'Packing',
+  'Shipment',
+];
+
+const stageMap: Record<string, string> = {
+  order_master: 'Order',
+  pre_stock: 'Pre-Stock',
+  planning: 'Planning',
+  cutting: 'Cutting',
+  printing: 'Printing',
+  embroidery: 'Embroidery',
+  sewing: 'Sewing',
+  finishing: 'Finishing',
+  packing: 'Packing',
+  shipment: 'Shipment',
+};
+
+const todayIso = () => new Date().toISOString().slice(0, 10);
+
+const addDays = (days: number) => {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  return date.toISOString().slice(0, 10);
+};
+
+const mockDashboard: DashboardData = {
+  source: 'mock',
+  orders: [
+    {
+      id: 'mock-order-1',
+      order_code: 'JT-260503-01',
+      status: 'running',
+      risk_level: 'amber',
+      shipment_date: addDays(4),
+      current_stage: 'sewing',
+    },
+    {
+      id: 'mock-order-2',
+      order_code: 'JT-260503-02',
+      status: 'released',
+      risk_level: 'red',
+      shipment_date: addDays(2),
+      current_stage: 'planning',
+    },
+    {
+      id: 'mock-order-3',
+      order_code: 'JT-260503-03',
+      status: 'active',
+      risk_level: 'green',
+      shipment_date: addDays(9),
+      current_stage: 'cutting',
+    },
+  ],
+  materials: [
+    { shortage_risk: 'red', readiness_percent: 72 },
+    { shortage_risk: 'amber', readiness_percent: 89 },
+    { shortage_risk: 'green', readiness_percent: 100 },
+  ],
+  hourly: [
+    { target_qty: 720, output_qty: 668 },
+    { target_qty: 620, output_qty: 558 },
+  ],
+  stages: [
+    { stage_name: 'cutting', status: 'running', risk_level: 'green' },
+    { stage_name: 'sewing', status: 'blocked', risk_level: 'red' },
+    { stage_name: 'packing', status: 'ready', risk_level: 'amber' },
+  ],
+  snapshot: {
+    id: 'mock-snapshot',
+    snapshot_date: todayIso(),
+    active_orders: 3,
+    orders_at_risk: 2,
+    shipments_this_week: 2,
+    material_shortages: 2,
+    factory_efficiency: 61.8,
+    production_achievement: 91.1,
+    open_management_actions: 3,
+    notes: 'Mock fallback visible because Supabase env values are missing.',
+    created_at: new Date().toISOString(),
+  },
+  actions: [
+    {
+      id: 'mock-action-1',
+      issue: 'Fabric gate below 95% for urgent shipment',
+      risk_level: 'red',
+      responsible_team: 'Pre-Stock',
+      required_decision: 'Approve split shipment or expedite balance',
+      due_date: addDays(1),
+      status: 'open',
+    },
+    {
+      id: 'mock-action-2',
+      issue: 'Sewing output behind daily target',
+      risk_level: 'amber',
+      responsible_team: 'Production',
+      required_decision: 'Move operators after lunch balancing',
+      due_date: todayIso(),
+      status: 'waiting_decision',
+    },
+  ],
+};
+
+export default function ExecutiveCommandCenter() {
+  const [data, setData] = useState<DashboardData>(mockDashboard);
+  const [loading, setLoading] = useState(isSupabaseConfigured);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadDashboard = async () => {
+      if (!supabase) {
+        setData(mockDashboard);
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+
+      const [
+        ordersResult,
+        materialsResult,
+        hourlyResult,
+        stagesResult,
+        snapshotResult,
+        actionsResult,
+      ] = await Promise.all([
+        supabase.from('orders').select('id, order_code, status, risk_level, shipment_date, current_stage'),
+        supabase.from('material_readiness').select('shortage_risk, readiness_percent'),
+        supabase.from('hourly_production').select('target_qty, output_qty'),
+        supabase.from('production_stage_records').select('stage_name, status, risk_level'),
+        supabase
+          .from('factory_snapshots')
+          .select('*')
+          .order('snapshot_date', { ascending: false })
+          .limit(1)
+          .maybeSingle(),
+        supabase
+          .from('management_actions')
+          .select('id, issue, risk_level, responsible_team, required_decision, due_date, status')
+          .neq('status', 'closed')
+          .order('due_date', { ascending: true, nullsFirst: false })
+          .limit(5),
+      ]);
+
+      const firstError =
+        ordersResult.error ??
+        materialsResult.error ??
+        hourlyResult.error ??
+        stagesResult.error ??
+        snapshotResult.error ??
+        actionsResult.error;
+
+      if (!isMounted) {
+        return;
+      }
+
+      if (firstError) {
+        setError(firstError.message);
+        setData({
+          source: 'supabase',
+          orders: [],
+          materials: [],
+          hourly: [],
+          stages: [],
+          snapshot: null,
+          actions: [],
+        });
+      } else {
+        setData({
+          source: 'supabase',
+          orders: ordersResult.data ?? [],
+          materials: materialsResult.data ?? [],
+          hourly: hourlyResult.data ?? [],
+          stages: stagesResult.data ?? [],
+          snapshot: snapshotResult.data ?? null,
+          actions: actionsResult.data ?? [],
+        });
+      }
+
+      setLoading(false);
+    };
+
+    void loadDashboard();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const metrics = useMemo(() => {
+    const activeOrders = data.orders.filter((order) =>
+      ['active', 'released', 'running'].includes(order.status),
+    ).length;
+    const ordersAtRisk = data.orders.filter((order) =>
+      ['red', 'critical', 'high', 'amber'].includes(order.risk_level),
+    ).length;
+    const shipmentsNextWeek = data.orders.filter((order) => {
+      if (!order.shipment_date) {
+        return false;
+      }
+
+      const shipDate = new Date(`${order.shipment_date}T00:00:00`);
+      const now = new Date();
+      now.setHours(0, 0, 0, 0);
+      const days = Math.ceil((shipDate.getTime() - now.getTime()) / 86_400_000);
+      return days >= 0 && days <= 7;
+    }).length;
+    const materialShortages = data.materials.filter((material) =>
+      ['red', 'critical', 'high', 'amber'].includes(material.shortage_risk),
+    ).length;
+    const totalTarget = data.hourly.reduce((sum, row) => sum + row.target_qty, 0);
+    const totalOutput = data.hourly.reduce((sum, row) => sum + row.output_qty, 0);
+
+    return {
+      activeOrders: data.snapshot?.active_orders ?? activeOrders,
+      ordersAtRisk: data.snapshot?.orders_at_risk ?? ordersAtRisk,
+      shipmentsNextWeek: data.snapshot?.shipments_this_week ?? shipmentsNextWeek,
+      materialShortages: data.snapshot?.material_shortages ?? materialShortages,
+      factoryEfficiency: data.snapshot?.factory_efficiency ?? 0,
+      productionAchievement:
+        data.snapshot?.production_achievement ?? productionAchievementPercent(totalOutput, totalTarget),
+      openActions: data.snapshot?.open_management_actions ?? data.actions.length,
+    };
+  }, [data]);
+
+  const flowStages = useMemo(
+    () =>
+      flowLabels.map((label) => {
+        const activeOrders = data.orders.filter((order) => stageMap[order.current_stage] === label).length;
+        const stageRows = data.stages.filter((stage) => stageMap[stage.stage_name] === label);
+        const blockedOrders = stageRows.filter((stage) =>
+          ['blocked', 'red', 'critical', 'high'].includes(stage.status) ||
+          ['red', 'critical', 'high'].includes(stage.risk_level),
+        ).length;
+
+        return { label, activeOrders, blockedOrders };
+      }),
+    [data.orders, data.stages],
+  );
+
+  const criticalAlerts = [
+    `${metrics.ordersAtRisk} orders need risk review`,
+    `${metrics.materialShortages} material gates below threshold`,
+    `${metrics.shipmentsNextWeek} shipments inside seven-day window`,
+  ];
+
+  return (
+    <section className="page-stack" aria-labelledby="executive-title">
+      <header className="page-header">
+        <div>
+          <p className="eyebrow">One Factory - One Database - One Management View</p>
+          <h2 id="executive-title">Executive Command Center</h2>
+        </div>
+        <div className="data-pill" data-source={data.source}>
+          {loading ? 'Loading Supabase' : data.source === 'mock' ? 'Mock fallback' : 'Supabase live'}
+        </div>
+      </header>
+
+      {error ? <div className="notice error">Supabase returned: {error}</div> : null}
+
+      <div className="kpi-grid">
+        <KpiCard label="Active Orders" value={String(metrics.activeOrders)} detail="Released and running" icon={<Boxes size={22} />} tone="blue" />
+        <KpiCard label="Orders at Risk" value={String(metrics.ordersAtRisk)} detail="Amber, red, high, critical" icon={<ShieldAlert size={22} />} tone={metrics.ordersAtRisk > 0 ? 'red' : 'green'} />
+        <KpiCard label="Shipments Next 7 Days" value={String(metrics.shipmentsNextWeek)} detail="Shipment date window" icon={<CalendarClock size={22} />} tone="amber" />
+        <KpiCard label="Material Shortage Orders" value={String(metrics.materialShortages)} detail="Readiness risk gate" icon={<PackageSearch size={22} />} tone={metrics.materialShortages > 0 ? 'red' : 'green'} />
+        <KpiCard label="Factory Efficiency" value={`${roundMetric(metrics.factoryEfficiency)}%`} detail="Latest factory snapshot" icon={<Gauge size={22} />} tone="green" />
+        <KpiCard label="Production Achievement" value={`${roundMetric(metrics.productionAchievement)}%`} detail="Actual output vs target" icon={<Target size={22} />} tone="blue" />
+        <KpiCard label="Open Management Actions" value={String(metrics.openActions)} detail="Open or waiting decision" icon={<ListChecks size={22} />} tone={metrics.openActions > 0 ? 'amber' : 'green'} />
+      </div>
+
+      <div className="command-grid">
+        <section className="command-panel wide-panel">
+          <div className="panel-heading">
+            <h3>Factory Flow Ribbon</h3>
+            <span>Order to shipment</span>
+          </div>
+          <FactoryFlowRibbon stages={flowStages} />
+        </section>
+
+        <section className="command-panel">
+          <div className="panel-heading">
+            <h3>Critical Alerts</h3>
+            <AlertTriangle size={18} />
+          </div>
+          <div className="alert-list">
+            {criticalAlerts.map((alert, index) => (
+              <div key={alert} className={`alert-row tone-${index === 0 ? riskTone('red') : riskTone('amber')}`}>
+                <strong>{alert}</strong>
+                <span>{index === 2 ? 'Commercial visibility' : 'Factory gate'}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="command-panel">
+          <div className="panel-heading">
+            <h3>Management Actions</h3>
+            <span>{data.actions.length} open</span>
+          </div>
+          <div className="action-list">
+            {data.actions.length === 0 ? (
+              <p className="empty-state">No open management actions.</p>
+            ) : (
+              data.actions.map((action) => (
+                <article key={action.id} className={`action-row tone-${riskTone(action.risk_level)}`}>
+                  <strong>{action.issue}</strong>
+                  <span>{action.responsible_team} - due {action.due_date ?? 'not set'}</span>
+                  <small>{action.required_decision ?? 'Decision not recorded'}</small>
+                </article>
+              ))
+            )}
+          </div>
+        </section>
+
+        <section className="command-panel">
+          <div className="panel-heading">
+            <h3>Jade Textile Agent Daily Insight</h3>
+            <Factory size={18} />
+          </div>
+          <p className="insight-copy">
+            Focus the morning meeting on orders tied to material readiness below gate, sewing output under
+            target, and shipments inside the next seven days. Keep actions connected to order, customer,
+            style, PO, line, group, and shipment date before escalation.
+          </p>
+        </section>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/SewingControlRoom.tsx
+++ b/src/pages/SewingControlRoom.tsx
@@ -1,8 +1,26 @@
 import { Factory, Layers3 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import LineTile, { type LineTileData } from '../components/LineTile';
-import { normalizeLineCode } from '../lib/riskRules';
+import { isGhostOrNonWorkingLine, normalizeLineCode } from '../lib/riskRules';
 import { isSupabaseConfigured, supabase } from '../lib/supabase';
+
+type AssignmentRow = {
+  line_id: string;
+  assignment_date: string;
+  status: string;
+  current_customer_name: string | null;
+  current_style_code: string | null;
+  current_po_number: string | null;
+  target_qty: number;
+  actual_qty: number;
+  manpower: number;
+  active_downtime_type: string | null;
+  orders: {
+    po_number: string | null;
+    shipment_date: string | null;
+    style_code: string;
+  } | null;
+};
 
 type LineQueryRow = {
   id: string;
@@ -17,23 +35,6 @@ type LineQueryRow = {
     group_code: string;
     group_name: string;
   } | null;
-  line_current_assignments:
-    | Array<{
-        status: string;
-        current_customer_name: string | null;
-        current_style_code: string | null;
-        current_po_number: string | null;
-        target_qty: number;
-        actual_qty: number;
-        manpower: number;
-        active_downtime_type: string | null;
-        orders: {
-          po_number: string | null;
-          shipment_date: string | null;
-          style_code: string;
-        } | null;
-      }>
-    | null;
 };
 
 const addDays = (days: number) => {
@@ -41,6 +42,8 @@ const addDays = (days: number) => {
   date.setDate(date.getDate() + days);
   return date.toISOString().slice(0, 10);
 };
+
+const todayIso = () => new Date().toISOString().slice(0, 10);
 
 const mockLines: LineTileData[] = [
   {
@@ -90,8 +93,17 @@ const mockLines: LineTileData[] = [
   },
 ];
 
-const toLineTile = (line: LineQueryRow): LineTileData => {
-  const assignment = line.line_current_assignments?.[0];
+const selectLatestAssignmentByLine = (assignments: AssignmentRow[]) => {
+  return assignments.reduce<Record<string, AssignmentRow>>((latestByLine, assignment) => {
+    const current = latestByLine[assignment.line_id];
+    if (!current || assignment.assignment_date > current.assignment_date) {
+      latestByLine[assignment.line_id] = assignment;
+    }
+    return latestByLine;
+  }, {});
+};
+
+const toLineTile = (line: LineQueryRow, assignment?: AssignmentRow): LineTileData => {
   const normalizedLineCode = normalizeLineCode(line.line_code);
   const group =
     line.production_groups?.group_name ??
@@ -99,6 +111,14 @@ const toLineTile = (line: LineQueryRow): LineTileData => {
     line.zone ??
     line.floor ??
     'Ungrouped';
+  const isGhost = isGhostOrNonWorkingLine({
+    lineCode: line.line_code,
+    groupCode: line.production_groups?.group_code,
+    zone: line.zone,
+    lineType: line.line_type,
+    isActive: line.is_active,
+    isCoreProduction: line.is_core_production,
+  });
 
   return {
     lineCode: normalizedLineCode,
@@ -107,12 +127,12 @@ const toLineTile = (line: LineQueryRow): LineTileData => {
     style: assignment?.current_style_code ?? assignment?.orders?.style_code ?? 'Idle',
     po: assignment?.current_po_number ?? assignment?.orders?.po_number ?? 'N/A',
     shipmentDate: assignment?.orders?.shipment_date ?? 'N/A',
-    status: assignment?.status ?? 'idle',
+    status: isGhost ? 'idle' : assignment?.status ?? 'idle',
     target: assignment?.target_qty ?? 0,
     actual: assignment?.actual_qty ?? 0,
     manpower: assignment?.manpower ?? 0,
-    activeDowntime: assignment?.active_downtime_type ?? 'none',
-    isActive: line.is_active && line.is_core_production && line.line_type !== 'ghost',
+    activeDowntime: isGhost ? 'ghost/non-working' : assignment?.active_downtime_type ?? 'none',
+    isActive: !isGhost,
     notes: line.notes ?? undefined,
   };
 };
@@ -137,20 +157,30 @@ export default function SewingControlRoom() {
       setLoading(true);
       setError(null);
 
-      const { data, error: queryError } = await supabase
-        .from('factory_lines')
-        .select(
-          `
-          id,
-          line_code,
-          zone,
-          floor,
-          line_type,
-          is_active,
-          is_core_production,
-          notes,
-          production_groups(group_code, group_name),
-          line_current_assignments(
+      const today = todayIso();
+      const [linesResult, todayAssignmentsResult] = await Promise.all([
+        supabase
+          .from('factory_lines')
+          .select(
+            `
+            id,
+            line_code,
+            zone,
+            floor,
+            line_type,
+            is_active,
+            is_core_production,
+            notes,
+            production_groups(group_code, group_name)
+          `,
+          )
+          .order('line_code', { ascending: true }),
+        supabase
+          .from('line_current_assignments')
+          .select(
+            `
+            line_id,
+            assignment_date,
             status,
             current_customer_name,
             current_style_code,
@@ -160,10 +190,11 @@ export default function SewingControlRoom() {
             manpower,
             active_downtime_type,
             orders(po_number, shipment_date, style_code)
+          `,
           )
-        `,
-        )
-        .order('line_code', { ascending: true });
+          .eq('assignment_date', today)
+          .order('assignment_date', { ascending: false }),
+      ]);
 
       if (!isMounted) {
         return;
@@ -171,11 +202,19 @@ export default function SewingControlRoom() {
 
       setSource('supabase');
 
-      if (queryError) {
-        setError(queryError.message);
+      const firstError = linesResult.error ?? todayAssignmentsResult.error;
+      if (firstError) {
+        setError(firstError.message);
         setLines([]);
       } else {
-        setLines(((data ?? []) as unknown as LineQueryRow[]).map(toLineTile));
+        const assignmentsByLine = selectLatestAssignmentByLine(
+          ((todayAssignmentsResult.data ?? []) as unknown as AssignmentRow[]),
+        );
+        setLines(
+          ((linesResult.data ?? []) as unknown as LineQueryRow[]).map((line) =>
+            toLineTile(line, assignmentsByLine[line.id]),
+          ),
+        );
       }
 
       setLoading(false);

--- a/src/pages/SewingControlRoom.tsx
+++ b/src/pages/SewingControlRoom.tsx
@@ -1,26 +1,8 @@
 import { Factory, Layers3 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import LineTile, { type LineTileData } from '../components/LineTile';
-import { isGhostOrNonWorkingLine, normalizeLineCode } from '../lib/riskRules';
+import { isGhostProductionArea, normalizeLineCode } from '../lib/riskRules';
 import { isSupabaseConfigured, supabase } from '../lib/supabase';
-
-type AssignmentRow = {
-  line_id: string;
-  assignment_date: string;
-  status: string;
-  current_customer_name: string | null;
-  current_style_code: string | null;
-  current_po_number: string | null;
-  target_qty: number;
-  actual_qty: number;
-  manpower: number;
-  active_downtime_type: string | null;
-  orders: {
-    po_number: string | null;
-    shipment_date: string | null;
-    style_code: string;
-  } | null;
-};
 
 type LineQueryRow = {
   id: string;
@@ -34,6 +16,27 @@ type LineQueryRow = {
   production_groups: {
     group_code: string;
     group_name: string;
+  } | null;
+};
+
+type AssignmentQueryRow = {
+  id: string;
+  line_id: string;
+  assignment_date: string;
+  status: string;
+  current_customer_name: string | null;
+  current_style_code: string | null;
+  current_po_number: string | null;
+  target_qty: number;
+  actual_qty: number;
+  manpower: number;
+  active_downtime_type: string | null;
+  last_event_at: string | null;
+  created_at: string;
+  orders: {
+    po_number: string | null;
+    shipment_date: string | null;
+    style_code: string;
   } | null;
 };
 
@@ -59,6 +62,7 @@ const mockLines: LineTileData[] = [
     manpower: 31,
     activeDowntime: 'none',
     isActive: true,
+    isGhost: false,
     notes: 'H93/115 legacy reference normalized to H93.',
   },
   {
@@ -74,6 +78,7 @@ const mockLines: LineTileData[] = [
     manpower: 28,
     activeDowntime: 'material',
     isActive: true,
+    isGhost: false,
     notes: 'G-14 correction preserved.',
   },
   {
@@ -89,21 +94,39 @@ const mockLines: LineTileData[] = [
     manpower: 0,
     activeDowntime: 'ghost line',
     isActive: false,
+    isGhost: true,
     notes: 'Ghost/non-working line.',
   },
 ];
 
-const selectLatestAssignmentByLine = (assignments: AssignmentRow[]) => {
-  return assignments.reduce<Record<string, AssignmentRow>>((latestByLine, assignment) => {
-    const current = latestByLine[assignment.line_id];
-    if (!current || assignment.assignment_date > current.assignment_date) {
-      latestByLine[assignment.line_id] = assignment;
+const assignmentTime = (assignment: AssignmentQueryRow) =>
+  new Date(assignment.last_event_at ?? assignment.created_at).getTime();
+
+const pickCurrentAssignment = (assignments: AssignmentQueryRow[], currentDate = todayIso()) => {
+  const todayAssignments = assignments.filter((assignment) => assignment.assignment_date === currentDate);
+  const candidates = todayAssignments.length > 0 ? todayAssignments : assignments;
+
+  return [...candidates].sort((left, right) => {
+    const dateCompare = right.assignment_date.localeCompare(left.assignment_date);
+    if (dateCompare !== 0) {
+      return dateCompare;
     }
-    return latestByLine;
-  }, {});
+
+    return assignmentTime(right) - assignmentTime(left);
+  })[0];
 };
 
-const toLineTile = (line: LineQueryRow, assignment?: AssignmentRow): LineTileData => {
+const groupAssignmentsByLine = (assignments: AssignmentQueryRow[]) =>
+  assignments.reduce<Record<string, AssignmentQueryRow[]>>((groups, assignment) => {
+    groups[assignment.line_id] = [...(groups[assignment.line_id] ?? []), assignment];
+    return groups;
+  }, {});
+
+const toLineTile = (
+  line: LineQueryRow,
+  assignmentsByLine: Record<string, AssignmentQueryRow[]>,
+): LineTileData => {
+  const assignment = pickCurrentAssignment(assignmentsByLine[line.id] ?? []);
   const normalizedLineCode = normalizeLineCode(line.line_code);
   const group =
     line.production_groups?.group_name ??
@@ -111,9 +134,10 @@ const toLineTile = (line: LineQueryRow, assignment?: AssignmentRow): LineTileDat
     line.zone ??
     line.floor ??
     'Ungrouped';
-  const isGhost = isGhostOrNonWorkingLine({
+  const isGhost = isGhostProductionArea({
     lineCode: line.line_code,
     groupCode: line.production_groups?.group_code,
+    groupName: line.production_groups?.group_name,
     zone: line.zone,
     lineType: line.line_type,
     isActive: line.is_active,
@@ -127,12 +151,13 @@ const toLineTile = (line: LineQueryRow, assignment?: AssignmentRow): LineTileDat
     style: assignment?.current_style_code ?? assignment?.orders?.style_code ?? 'Idle',
     po: assignment?.current_po_number ?? assignment?.orders?.po_number ?? 'N/A',
     shipmentDate: assignment?.orders?.shipment_date ?? 'N/A',
-    status: isGhost ? 'idle' : assignment?.status ?? 'idle',
+    status: isGhost ? 'idle' : (assignment?.status ?? 'idle'),
     target: assignment?.target_qty ?? 0,
     actual: assignment?.actual_qty ?? 0,
     manpower: assignment?.manpower ?? 0,
-    activeDowntime: isGhost ? 'ghost/non-working' : assignment?.active_downtime_type ?? 'none',
+    activeDowntime: isGhost ? 'ghost/non-working' : (assignment?.active_downtime_type ?? 'none'),
     isActive: !isGhost,
+    isGhost,
     notes: line.notes ?? undefined,
   };
 };
@@ -157,44 +182,53 @@ export default function SewingControlRoom() {
       setLoading(true);
       setError(null);
 
-      const today = todayIso();
-      const [linesResult, todayAssignmentsResult] = await Promise.all([
-        supabase
-          .from('factory_lines')
-          .select(
-            `
-            id,
-            line_code,
-            zone,
-            floor,
-            line_type,
-            is_active,
-            is_core_production,
-            notes,
-            production_groups(group_code, group_name)
-          `,
-          )
-          .order('line_code', { ascending: true }),
-        supabase
-          .from('line_current_assignments')
-          .select(
-            `
-            line_id,
-            assignment_date,
-            status,
-            current_customer_name,
-            current_style_code,
-            current_po_number,
-            target_qty,
-            actual_qty,
-            manpower,
-            active_downtime_type,
-            orders(po_number, shipment_date, style_code)
-          `,
-          )
-          .eq('assignment_date', today)
-          .order('assignment_date', { ascending: false }),
-      ]);
+      const linesResult = await supabase
+        .from('factory_lines')
+        .select(
+          `
+          id,
+          line_code,
+          zone,
+          floor,
+          line_type,
+          is_active,
+          is_core_production,
+          notes,
+          production_groups(group_code, group_name)
+        `,
+        )
+        .order('line_code', { ascending: true });
+
+      const lineRows = (linesResult.data ?? []) as unknown as LineQueryRow[];
+      const lineIds = lineRows.map((line) => line.id);
+
+      const assignmentsResult =
+        lineIds.length === 0
+          ? { data: [], error: null }
+          : await supabase
+              .from('line_current_assignments')
+              .select(
+                `
+                id,
+                line_id,
+                assignment_date,
+                status,
+                current_customer_name,
+                current_style_code,
+                current_po_number,
+                target_qty,
+                actual_qty,
+                manpower,
+                active_downtime_type,
+                last_event_at,
+                created_at,
+                orders(po_number, shipment_date, style_code)
+              `,
+              )
+              .in('line_id', lineIds)
+              .order('assignment_date', { ascending: false })
+              .order('last_event_at', { ascending: false, nullsFirst: false })
+              .order('created_at', { ascending: false });
 
       if (!isMounted) {
         return;
@@ -202,19 +236,16 @@ export default function SewingControlRoom() {
 
       setSource('supabase');
 
-      const firstError = linesResult.error ?? todayAssignmentsResult.error;
-      if (firstError) {
-        setError(firstError.message);
+      const queryError = linesResult.error ?? assignmentsResult.error;
+
+      if (queryError) {
+        setError(queryError.message);
         setLines([]);
       } else {
-        const assignmentsByLine = selectLatestAssignmentByLine(
-          ((todayAssignmentsResult.data ?? []) as unknown as AssignmentRow[]),
+        const assignmentsByLine = groupAssignmentsByLine(
+          (assignmentsResult.data ?? []) as unknown as AssignmentQueryRow[],
         );
-        setLines(
-          ((linesResult.data ?? []) as unknown as LineQueryRow[]).map((line) =>
-            toLineTile(line, assignmentsByLine[line.id]),
-          ),
-        );
+        setLines(lineRows.map((line) => toLineTile(line, assignmentsByLine)));
       }
 
       setLoading(false);

--- a/src/pages/SewingControlRoom.tsx
+++ b/src/pages/SewingControlRoom.tsx
@@ -1,0 +1,271 @@
+import { Factory, Layers3 } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import LineTile, { type LineTileData } from '../components/LineTile';
+import { normalizeLineCode } from '../lib/riskRules';
+import { isSupabaseConfigured, supabase } from '../lib/supabase';
+
+type LineQueryRow = {
+  id: string;
+  line_code: string;
+  zone: string | null;
+  floor: string | null;
+  line_type: string;
+  is_active: boolean;
+  is_core_production: boolean;
+  notes: string | null;
+  production_groups: {
+    group_code: string;
+    group_name: string;
+  } | null;
+  line_current_assignments:
+    | Array<{
+        status: string;
+        current_customer_name: string | null;
+        current_style_code: string | null;
+        current_po_number: string | null;
+        target_qty: number;
+        actual_qty: number;
+        manpower: number;
+        active_downtime_type: string | null;
+        orders: {
+          po_number: string | null;
+          shipment_date: string | null;
+          style_code: string;
+        } | null;
+      }>
+    | null;
+};
+
+const addDays = (days: number) => {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  return date.toISOString().slice(0, 10);
+};
+
+const mockLines: LineTileData[] = [
+  {
+    lineCode: 'H93',
+    group: 'Group H',
+    customer: 'Jade Export',
+    style: 'JTX-2401',
+    po: 'PO-8831',
+    shipmentDate: addDays(5),
+    status: 'running',
+    target: 720,
+    actual: 668,
+    manpower: 31,
+    activeDowntime: 'none',
+    isActive: true,
+    notes: 'H93/115 legacy reference normalized to H93.',
+  },
+  {
+    lineCode: 'G-14',
+    group: 'Group G',
+    customer: 'North Retail',
+    style: 'NR-5510',
+    po: 'PO-9014',
+    shipmentDate: addDays(2),
+    status: 'warning',
+    target: 620,
+    actual: 498,
+    manpower: 28,
+    activeDowntime: 'material',
+    isActive: true,
+    notes: 'G-14 correction preserved.',
+  },
+  {
+    lineCode: 'G-11',
+    group: 'Ghost / Non-working',
+    customer: 'Unassigned',
+    style: 'Idle',
+    po: 'N/A',
+    shipmentDate: 'N/A',
+    status: 'idle',
+    target: 0,
+    actual: 0,
+    manpower: 0,
+    activeDowntime: 'ghost line',
+    isActive: false,
+    notes: 'Ghost/non-working line.',
+  },
+];
+
+const toLineTile = (line: LineQueryRow): LineTileData => {
+  const assignment = line.line_current_assignments?.[0];
+  const normalizedLineCode = normalizeLineCode(line.line_code);
+  const group =
+    line.production_groups?.group_name ??
+    line.production_groups?.group_code ??
+    line.zone ??
+    line.floor ??
+    'Ungrouped';
+
+  return {
+    lineCode: normalizedLineCode,
+    group,
+    customer: assignment?.current_customer_name ?? 'Unassigned',
+    style: assignment?.current_style_code ?? assignment?.orders?.style_code ?? 'Idle',
+    po: assignment?.current_po_number ?? assignment?.orders?.po_number ?? 'N/A',
+    shipmentDate: assignment?.orders?.shipment_date ?? 'N/A',
+    status: assignment?.status ?? 'idle',
+    target: assignment?.target_qty ?? 0,
+    actual: assignment?.actual_qty ?? 0,
+    manpower: assignment?.manpower ?? 0,
+    activeDowntime: assignment?.active_downtime_type ?? 'none',
+    isActive: line.is_active && line.is_core_production && line.line_type !== 'ghost',
+    notes: line.notes ?? undefined,
+  };
+};
+
+export default function SewingControlRoom() {
+  const [lines, setLines] = useState<LineTileData[]>(mockLines);
+  const [source, setSource] = useState<'supabase' | 'mock'>('mock');
+  const [loading, setLoading] = useState(isSupabaseConfigured);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadLines = async () => {
+      if (!supabase) {
+        setLines(mockLines);
+        setSource('mock');
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+
+      const { data, error: queryError } = await supabase
+        .from('factory_lines')
+        .select(
+          `
+          id,
+          line_code,
+          zone,
+          floor,
+          line_type,
+          is_active,
+          is_core_production,
+          notes,
+          production_groups(group_code, group_name),
+          line_current_assignments(
+            status,
+            current_customer_name,
+            current_style_code,
+            current_po_number,
+            target_qty,
+            actual_qty,
+            manpower,
+            active_downtime_type,
+            orders(po_number, shipment_date, style_code)
+          )
+        `,
+        )
+        .order('line_code', { ascending: true });
+
+      if (!isMounted) {
+        return;
+      }
+
+      setSource('supabase');
+
+      if (queryError) {
+        setError(queryError.message);
+        setLines([]);
+      } else {
+        setLines(((data ?? []) as unknown as LineQueryRow[]).map(toLineTile));
+      }
+
+      setLoading(false);
+    };
+
+    void loadLines();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const groupedLines = useMemo(() => {
+    return lines.reduce<Record<string, LineTileData[]>>((groups, line) => {
+      const groupName = line.group || 'Ungrouped';
+      groups[groupName] = [...(groups[groupName] ?? []), line];
+      return groups;
+    }, {});
+  }, [lines]);
+
+  const runningCount = lines.filter((line) => line.status === 'running').length;
+  const riskCount = lines.filter((line) => ['warning', 'stopped', 'blocked'].includes(line.status)).length;
+
+  return (
+    <section className="page-stack" aria-labelledby="sewing-title">
+      <header className="page-header">
+        <div>
+          <p className="eyebrow">Factory lines generated from Supabase tables</p>
+          <h2 id="sewing-title">Sewing Control Room</h2>
+        </div>
+        <div className="data-pill" data-source={source}>
+          {loading ? 'Loading lines' : source === 'mock' ? 'Mock fallback' : 'Supabase live'}
+        </div>
+      </header>
+
+      {error ? <div className="notice error">Supabase returned: {error}</div> : null}
+
+      <div className="sewing-summary">
+        <div>
+          <Factory size={20} />
+          <span>
+            <strong>{lines.length}</strong>
+            <small>Total lines</small>
+          </span>
+        </div>
+        <div>
+          <Layers3 size={20} />
+          <span>
+            <strong>{Object.keys(groupedLines).length}</strong>
+            <small>Groups / zones</small>
+          </span>
+        </div>
+        <div>
+          <span className="status-dot green" />
+          <span>
+            <strong>{runningCount}</strong>
+            <small>Running</small>
+          </span>
+        </div>
+        <div>
+          <span className="status-dot amber" />
+          <span>
+            <strong>{riskCount}</strong>
+            <small>Warning / stopped</small>
+          </span>
+        </div>
+      </div>
+
+      {lines.length === 0 ? (
+        <div className="empty-state framed">
+          No factory lines returned. Apply the seed file or add rows to factory_lines and
+          line_current_assignments in Supabase.
+        </div>
+      ) : (
+        <div className="line-groups">
+          {Object.entries(groupedLines).map(([group, groupLines]) => (
+            <section key={group} className="line-group" aria-labelledby={`group-${group}`}>
+              <div className="panel-heading">
+                <h3 id={`group-${group}`}>{group}</h3>
+                <span>{groupLines.length} lines</span>
+              </div>
+              <div className="line-grid">
+                {groupLines.map((line) => (
+                  <LineTile key={`${group}-${line.lineCode}`} line={line} />
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,0 +1,525 @@
+:root {
+  color-scheme: dark;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #0d1110;
+  color: #eef4ef;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-inline-size: 320px;
+  min-block-size: 100vh;
+  background: #0d1110;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+button {
+  color: inherit;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: minmax(250px, 290px) 1fr;
+  min-block-size: 100vh;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.035), transparent 220px),
+    #0d1110;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  padding: 22px;
+  border-inline-start: 1px solid rgba(255, 255, 255, 0.08);
+  background: #151a18;
+}
+
+.brand-block {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.brand-mark {
+  display: grid;
+  place-items: center;
+  inline-size: 42px;
+  block-size: 42px;
+  border: 1px solid rgba(52, 211, 153, 0.45);
+  border-radius: 8px;
+  color: #34d399;
+  background: rgba(52, 211, 153, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 4px;
+  color: #8fa09a;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.brand-block h1,
+.page-header h2 {
+  margin: 0;
+  font-size: 1.18rem;
+  line-height: 1.15;
+}
+
+.view-tabs {
+  display: grid;
+  gap: 10px;
+}
+
+.view-tab {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  inline-size: 100%;
+  padding: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  background: #1a211e;
+  text-align: start;
+  cursor: pointer;
+}
+
+.view-tab.active {
+  border-color: rgba(52, 211, 153, 0.55);
+  background: #202b26;
+}
+
+.view-tab span,
+.sidebar-status span,
+.sewing-summary span {
+  display: grid;
+  gap: 3px;
+}
+
+.view-tab small,
+.sidebar-status small,
+.sewing-summary small,
+.line-order small,
+.panel-heading span,
+.flow-stage small,
+.kpi-card span,
+.action-row small {
+  color: #8fa09a;
+  font-size: 0.76rem;
+}
+
+.sidebar-status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-block-start: auto;
+  padding: 12px;
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  border-radius: 8px;
+  color: #fbbf24;
+  background: rgba(245, 158, 11, 0.08);
+}
+
+.workspace {
+  min-inline-size: 0;
+  padding: 22px;
+}
+
+.page-stack {
+  display: grid;
+  gap: 18px;
+}
+
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.data-pill {
+  padding: 8px 11px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  color: #cbd5d1;
+  background: #171d1b;
+  font-size: 0.78rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.data-pill[data-source="mock"] {
+  border-color: rgba(245, 158, 11, 0.45);
+  color: #fbbf24;
+}
+
+.data-pill[data-source="supabase"] {
+  border-color: rgba(52, 211, 153, 0.45);
+  color: #6ee7b7;
+}
+
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(140px, 1fr));
+  gap: 10px;
+}
+
+.kpi-card,
+.command-panel,
+.line-group,
+.line-tile,
+.sewing-summary > div,
+.notice,
+.empty-state.framed {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  background: #161c1a;
+}
+
+.kpi-card {
+  display: grid;
+  gap: 12px;
+  min-block-size: 136px;
+  padding: 14px;
+}
+
+.kpi-card p,
+.kpi-card strong,
+.kpi-card span {
+  margin: 0;
+}
+
+.kpi-card p {
+  min-block-size: 34px;
+  color: #b9c5c0;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.kpi-card strong {
+  display: block;
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.kpi-icon {
+  display: grid;
+  place-items: center;
+  inline-size: 34px;
+  block-size: 34px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.tone-green {
+  --tone: #34d399;
+}
+
+.tone-amber {
+  --tone: #f59e0b;
+}
+
+.tone-red {
+  --tone: #ef4444;
+}
+
+.tone-blue {
+  --tone: #38bdf8;
+}
+
+.tone-gray {
+  --tone: #94a3b8;
+}
+
+.kpi-card,
+.line-tile,
+.alert-row,
+.action-row {
+  border-block-start-color: color-mix(in srgb, var(--tone) 70%, transparent);
+}
+
+.kpi-icon,
+.line-tile em,
+.status-dot {
+  color: var(--tone);
+}
+
+.command-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.65fr);
+  gap: 12px;
+}
+
+.wide-panel {
+  grid-column: 1 / -1;
+}
+
+.command-panel,
+.line-group {
+  padding: 16px;
+}
+
+.panel-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-block-end: 14px;
+}
+
+.panel-heading h3 {
+  margin: 0;
+  font-size: 0.98rem;
+}
+
+.flow-ribbon {
+  display: grid;
+  grid-template-columns: repeat(10, minmax(100px, 1fr));
+  gap: 8px;
+  overflow-x: auto;
+  padding-block-end: 4px;
+}
+
+.flow-stage {
+  min-inline-size: 110px;
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  background: #111715;
+}
+
+.flow-stage.live {
+  border-color: rgba(52, 211, 153, 0.32);
+}
+
+.flow-stage.blocked {
+  border-color: rgba(239, 68, 68, 0.45);
+}
+
+.flow-index {
+  display: block;
+  margin-block-end: 18px;
+  color: #8fa09a;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.flow-stage strong,
+.flow-stage small {
+  display: block;
+}
+
+.alert-list,
+.action-list,
+.line-groups {
+  display: grid;
+  gap: 10px;
+}
+
+.alert-row,
+.action-row {
+  display: grid;
+  gap: 4px;
+  padding: 11px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  background: #111715;
+}
+
+.alert-row span,
+.action-row span {
+  color: #b9c5c0;
+  font-size: 0.78rem;
+}
+
+.insight-copy {
+  margin: 0;
+  color: #cbd5d1;
+  line-height: 1.7;
+}
+
+.notice,
+.empty-state.framed {
+  padding: 12px;
+}
+
+.notice.error {
+  border-color: rgba(239, 68, 68, 0.45);
+  color: #fecaca;
+}
+
+.empty-state {
+  margin: 0;
+  color: #8fa09a;
+}
+
+.sewing-summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(160px, 1fr));
+  gap: 10px;
+}
+
+.sewing-summary > div {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 13px;
+}
+
+.sewing-summary strong {
+  font-size: 1.28rem;
+}
+
+.status-dot {
+  display: inline-block;
+  inline-size: 12px;
+  block-size: 12px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.status-dot.green {
+  color: #34d399;
+}
+
+.status-dot.amber {
+  color: #f59e0b;
+}
+
+.line-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 10px;
+}
+
+.line-tile {
+  display: grid;
+  gap: 13px;
+  padding: 13px;
+}
+
+.line-tile header,
+.line-tile footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.line-tile header div,
+.line-order {
+  display: grid;
+  gap: 4px;
+}
+
+.line-tile header strong {
+  font-size: 1.25rem;
+}
+
+.line-tile header span,
+.line-order span {
+  color: #b9c5c0;
+  font-size: 0.8rem;
+}
+
+.line-tile em {
+  padding: 5px 8px;
+  border: 1px solid color-mix(in srgb, var(--tone) 42%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--tone) 10%, transparent);
+  font-size: 0.74rem;
+  font-style: normal;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.line-order strong {
+  font-size: 1rem;
+}
+
+.line-meter {
+  overflow: hidden;
+  inline-size: 100%;
+  block-size: 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.line-meter span {
+  display: block;
+  block-size: 100%;
+  border-radius: inherit;
+  background: var(--tone);
+}
+
+.line-tile footer span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #cbd5d1;
+  font-size: 0.8rem;
+}
+
+@media (max-width: 1180px) {
+  .kpi-grid {
+    grid-template-columns: repeat(3, minmax(160px, 1fr));
+  }
+
+  .flow-ribbon {
+    grid-template-columns: repeat(5, minmax(130px, 1fr));
+  }
+}
+
+@media (max-width: 880px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: static;
+    border-inline-start: 0;
+    border-block-end: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  .view-tabs,
+  .sewing-summary,
+  .command-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .kpi-grid {
+    grid-template-columns: repeat(2, minmax(140px, 1fr));
+  }
+}
+
+@media (max-width: 560px) {
+  .workspace,
+  .sidebar {
+    padding: 14px;
+  }
+
+  .page-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .kpi-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,0 +1,213 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+type Table<Row, Insert = Partial<Row>, Update = Partial<Row>> = {
+  Row: Row;
+  Insert: Insert;
+  Update: Update;
+  Relationships: [];
+};
+
+export type Database = {
+  public: {
+    Tables: {
+      orders: Table<{
+        color: string | null;
+        created_at: string;
+        current_stage: string;
+        customer_id: string | null;
+        delivery_date: string | null;
+        id: string;
+        order_code: string;
+        order_quantity: number;
+        po_number: string | null;
+        priority: string;
+        risk_level: string;
+        shipment_date: string | null;
+        size_breakdown: Json;
+        special_process_required: boolean;
+        status: string;
+        style_code: string;
+        style_id: string | null;
+        updated_at: string;
+      }>;
+      customers: Table<{
+        created_at: string;
+        customer_code: string;
+        customer_group: string | null;
+        customer_name: string;
+        id: string;
+        status: string;
+        updated_at: string;
+      }>;
+      style_master: Table<{
+        created_at: string;
+        customer_id: string | null;
+        customer_name: string | null;
+        default_smv: number | null;
+        embroidery_required: boolean;
+        fabric_family: string | null;
+        id: string;
+        print_required: boolean;
+        product_category: string | null;
+        special_process_required: boolean;
+        status: string;
+        style_code: string;
+        style_description: string | null;
+        updated_at: string;
+      }>;
+      production_groups: Table<{
+        created_at: string;
+        group_code: string;
+        group_name: string;
+        id: string;
+        is_active: boolean;
+        notes: string | null;
+        updated_at: string;
+      }>;
+      factory_lines: Table<{
+        created_at: string;
+        floor: string | null;
+        group_id: string | null;
+        id: string;
+        is_active: boolean;
+        is_core_production: boolean;
+        line_code: string;
+        line_type: string;
+        notes: string | null;
+        updated_at: string;
+        zone: string | null;
+      }>;
+      line_current_assignments: Table<{
+        active_downtime_type: string | null;
+        actual_qty: number;
+        assignment_date: string;
+        created_at: string;
+        current_customer_name: string | null;
+        current_po_number: string | null;
+        current_style_code: string | null;
+        customer_id: string | null;
+        id: string;
+        last_event_at: string | null;
+        line_id: string;
+        manpower: number;
+        notes: string | null;
+        order_id: string | null;
+        plan_id: string | null;
+        status: string;
+        style_id: string | null;
+        target_qty: number;
+        updated_at: string;
+      }>;
+      material_readiness: Table<{
+        approval_status: string;
+        balance_qty: number | null;
+        created_at: string;
+        expected_inhouse_date: string | null;
+        id: string;
+        inspection_status: string;
+        material_type: string;
+        notes: string | null;
+        order_id: string;
+        readiness_percent: number | null;
+        received_qty: number;
+        required_qty: number;
+        shortage_risk: string;
+        updated_at: string;
+      }>;
+      production_stage_records: Table<{
+        balance_qty: number | null;
+        created_at: string;
+        finish_date: string | null;
+        id: string;
+        input_qty: number;
+        notes: string | null;
+        order_id: string;
+        output_qty: number;
+        plan_id: string | null;
+        reject_qty: number;
+        responsible_team: string | null;
+        rework_qty: number;
+        risk_level: string;
+        stage_name: string;
+        start_date: string | null;
+        status: string;
+        updated_at: string;
+      }>;
+      hourly_production: Table<{
+        created_at: string;
+        defect_qty: number;
+        downtime_minutes: number;
+        hour_slot: string;
+        id: string;
+        line_id: string | null;
+        manpower: number;
+        order_id: string;
+        output_qty: number;
+        plan_id: string | null;
+        production_date: string;
+        remarks: string | null;
+        target_qty: number;
+        updated_at: string;
+      }>;
+      factory_snapshots: Table<{
+        active_orders: number;
+        created_at: string;
+        factory_efficiency: number | null;
+        id: string;
+        material_shortages: number;
+        notes: string | null;
+        open_management_actions: number;
+        orders_at_risk: number;
+        production_achievement: number | null;
+        shipments_this_week: number;
+        snapshot_date: string;
+      }>;
+      management_actions: Table<{
+        closed_at: string | null;
+        created_at: string;
+        due_date: string | null;
+        expected_impact: string | null;
+        id: string;
+        issue: string;
+        order_id: string | null;
+        required_decision: string | null;
+        responsible_team: string;
+        risk_level: string;
+        status: string;
+        updated_at: string;
+      }>;
+      app_settings: Table<{
+        created_at: string;
+        description: string | null;
+        id: string;
+        setting_key: string;
+        setting_value: Json;
+        updated_at: string;
+      }>;
+      audit_events: Table<{
+        actor_name: string | null;
+        created_at: string;
+        entity_id: string | null;
+        entity_table: string;
+        event_summary: string;
+        event_type: string;
+        id: string;
+        new_values: Json | null;
+        old_values: Json | null;
+      }>;
+    };
+    Views: Record<string, never>;
+    Functions: Record<string, never>;
+    Enums: Record<string, never>;
+    CompositeTypes: Record<string, never>;
+  };
+};
+
+export type Tables<TableName extends keyof Database['public']['Tables']> =
+  Database['public']['Tables'][TableName]['Row'];

--- a/supabase/migrations/001_foundation_schema.sql
+++ b/supabase/migrations/001_foundation_schema.sql
@@ -1,0 +1,183 @@
+create extension if not exists pgcrypto with schema extensions;
+
+create table if not exists public.customers (
+  id uuid primary key default gen_random_uuid(),
+  customer_code text not null unique,
+  customer_name text not null,
+  customer_group text,
+  status text not null default 'active',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.production_groups (
+  id uuid primary key default gen_random_uuid(),
+  group_code text not null unique,
+  group_name text not null,
+  is_active boolean not null default true,
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.factory_lines (
+  id uuid primary key default gen_random_uuid(),
+  line_code text not null unique,
+  zone text,
+  floor text,
+  line_type text not null default 'production',
+  is_active boolean not null default true,
+  is_core_production boolean not null default true,
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  group_id uuid references public.production_groups(id)
+);
+
+create table if not exists public.style_master (
+  id uuid primary key default gen_random_uuid(),
+  customer_id uuid references public.customers(id),
+  customer_name text,
+  style_code text not null,
+  style_description text,
+  product_category text,
+  fabric_family text,
+  default_smv numeric,
+  special_process_required boolean not null default false,
+  print_required boolean not null default false,
+  embroidery_required boolean not null default false,
+  status text not null default 'active',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.orders (
+  id uuid primary key default gen_random_uuid(),
+  order_code text not null unique,
+  customer_id uuid references public.customers(id),
+  style_id uuid references public.style_master(id),
+  po_number text,
+  style_code text not null,
+  color text,
+  size_breakdown jsonb not null default '{}'::jsonb,
+  order_quantity integer not null check (order_quantity >= 0),
+  delivery_date date,
+  shipment_date date,
+  priority text not null default 'normal'
+    check (priority in ('low', 'normal', 'high', 'urgent')),
+  special_process_required boolean not null default false,
+  current_stage text not null default 'order_master',
+  risk_level text not null default 'not_assessed'
+    check (risk_level in ('not_assessed', 'green', 'amber', 'red', 'critical', 'high')),
+  status text not null default 'draft'
+    check (status in ('draft', 'active', 'released', 'running', 'completed', 'cancelled', 'on_hold')),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.material_readiness (
+  id uuid primary key default gen_random_uuid(),
+  order_id uuid not null references public.orders(id),
+  material_type text not null
+    check (material_type in ('fabric', 'trims', 'accessories', 'packing_material', 'printing_material', 'embroidery_material')),
+  required_qty numeric not null default 0,
+  received_qty numeric not null default 0,
+  balance_qty numeric generated always as (greatest(required_qty - received_qty, 0)) stored,
+  readiness_percent numeric generated always as (
+    case when required_qty > 0 then round((received_qty / required_qty) * 100, 2) else 0 end
+  ) stored,
+  expected_inhouse_date date,
+  inspection_status text not null default 'pending',
+  approval_status text not null default 'pending',
+  shortage_risk text not null default 'not_assessed',
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.production_plans (
+  id uuid primary key default gen_random_uuid(),
+  order_id uuid not null references public.orders(id),
+  line_id uuid references public.factory_lines(id),
+  plan_code text unique,
+  smv numeric not null check (smv > 0),
+  efficiency_assumption numeric not null default 55 check (efficiency_assumption > 0),
+  working_minutes_per_day integer not null default 540,
+  required_operators integer not null default 0,
+  daily_target integer,
+  planned_start_date date,
+  planned_finish_date date,
+  required_days numeric,
+  capacity_risk text not null default 'not_assessed',
+  status text not null default 'draft',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.production_stage_records (
+  id uuid primary key default gen_random_uuid(),
+  order_id uuid not null references public.orders(id),
+  plan_id uuid references public.production_plans(id),
+  stage_name text not null
+    check (stage_name in ('cutting', 'printing', 'embroidery', 'sewing', 'finishing', 'packing', 'shipment')),
+  input_qty integer not null default 0,
+  output_qty integer not null default 0,
+  balance_qty integer generated always as (greatest(input_qty - output_qty, 0)) stored,
+  rework_qty integer not null default 0,
+  reject_qty integer not null default 0,
+  start_date date,
+  finish_date date,
+  status text not null default 'not_started'
+    check (status in ('not_started', 'ready', 'running', 'blocked', 'completed', 'on_hold')),
+  risk_level text not null default 'not_assessed',
+  responsible_team text,
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.factory_snapshots (
+  id uuid primary key default gen_random_uuid(),
+  snapshot_date date not null default current_date,
+  active_orders integer not null default 0,
+  orders_at_risk integer not null default 0,
+  shipments_this_week integer not null default 0,
+  material_shortages integer not null default 0,
+  factory_efficiency numeric,
+  production_achievement numeric,
+  open_management_actions integer not null default 0,
+  notes text,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.app_settings (
+  id uuid primary key default gen_random_uuid(),
+  setting_key text not null unique,
+  setting_value jsonb not null default '{}'::jsonb,
+  description text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_factory_lines_group_id on public.factory_lines(group_id);
+create index if not exists idx_style_master_customer_id on public.style_master(customer_id);
+create index if not exists idx_orders_customer_id on public.orders(customer_id);
+create index if not exists idx_orders_style_id on public.orders(style_id);
+create index if not exists idx_orders_shipment_date on public.orders(shipment_date);
+create index if not exists idx_material_readiness_order_id on public.material_readiness(order_id);
+create index if not exists idx_production_plans_order_id on public.production_plans(order_id);
+create index if not exists idx_production_plans_line_id on public.production_plans(line_id);
+create index if not exists idx_stage_records_order_id on public.production_stage_records(order_id);
+create index if not exists idx_stage_records_plan_id on public.production_stage_records(plan_id);
+create index if not exists idx_factory_snapshots_date on public.factory_snapshots(snapshot_date desc);
+
+alter table public.customers enable row level security;
+alter table public.production_groups enable row level security;
+alter table public.factory_lines enable row level security;
+alter table public.style_master enable row level security;
+alter table public.orders enable row level security;
+alter table public.material_readiness enable row level security;
+alter table public.production_plans enable row level security;
+alter table public.production_stage_records enable row level security;
+alter table public.factory_snapshots enable row level security;
+alter table public.app_settings enable row level security;

--- a/supabase/migrations/002_execution_layer.sql
+++ b/supabase/migrations/002_execution_layer.sql
@@ -1,0 +1,185 @@
+create table if not exists public.line_current_assignments (
+  id uuid primary key default gen_random_uuid(),
+  line_id uuid not null references public.factory_lines(id),
+  order_id uuid references public.orders(id),
+  plan_id uuid references public.production_plans(id),
+  customer_id uuid references public.customers(id),
+  style_id uuid references public.style_master(id),
+  assignment_date date not null default current_date,
+  status text not null default 'idle'
+    check (status in ('idle', 'running', 'warning', 'stopped', 'changeover', 'blocked')),
+  current_customer_name text,
+  current_style_code text,
+  current_po_number text,
+  target_qty integer not null default 0,
+  actual_qty integer not null default 0,
+  manpower integer not null default 0,
+  active_downtime_type text,
+  last_event_at timestamptz,
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.hourly_production (
+  id uuid primary key default gen_random_uuid(),
+  order_id uuid not null references public.orders(id),
+  plan_id uuid references public.production_plans(id),
+  line_id uuid references public.factory_lines(id),
+  production_date date not null,
+  hour_slot text not null,
+  manpower integer not null default 0,
+  target_qty integer not null default 0,
+  output_qty integer not null default 0,
+  downtime_minutes integer not null default 0,
+  defect_qty integer not null default 0,
+  remarks text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.downtime_events (
+  id uuid primary key default gen_random_uuid(),
+  line_id uuid not null references public.factory_lines(id),
+  order_id uuid references public.orders(id),
+  plan_id uuid references public.production_plans(id),
+  downtime_type text not null
+    check (downtime_type in ('changeover', 'maintenance', 'material', 'quality', 'factory')),
+  reason text,
+  phase text,
+  started_at timestamptz not null default now(),
+  ended_at timestamptz,
+  duration_minutes integer,
+  operators_count integer not null default 0,
+  total_lost_minutes integer,
+  status text not null default 'open'
+    check (status in ('open', 'waiting', 'repairing', 'resolved', 'cancelled')),
+  abnormal_reason text,
+  responsible_team text,
+  action_taken text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.manpower_logs (
+  id uuid primary key default gen_random_uuid(),
+  line_id uuid not null references public.factory_lines(id),
+  order_id uuid references public.orders(id),
+  log_date date not null default current_date,
+  required_operators integer not null default 0,
+  actual_operators integer not null default 0,
+  singer_required integer not null default 0,
+  singer_actual integer not null default 0,
+  overlock_required integer not null default 0,
+  overlock_actual integer not null default 0,
+  coverstitch_required integer not null default 0,
+  coverstitch_actual integer not null default 0,
+  chain_required integer not null default 0,
+  chain_actual integer not null default 0,
+  gap integer generated always as (required_operators - actual_operators) stored,
+  recommendation text,
+  status text not null default 'open'
+    check (status in ('open', 'balanced', 'shortage', 'surplus', 'resolved')),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.quality_records (
+  id uuid primary key default gen_random_uuid(),
+  order_id uuid not null references public.orders(id),
+  stage_record_id uuid references public.production_stage_records(id),
+  inspection_type text not null,
+  defect_type text,
+  checked_qty integer not null default 0,
+  defect_qty integer not null default 0,
+  dhu numeric generated always as (
+    case when checked_qty > 0 then round((defect_qty::numeric / checked_qty::numeric) * 100, 2) else 0 end
+  ) stored,
+  rework_qty integer not null default 0,
+  reject_qty integer not null default 0,
+  corrective_action text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.management_actions (
+  id uuid primary key default gen_random_uuid(),
+  order_id uuid references public.orders(id),
+  issue text not null,
+  risk_level text not null default 'medium'
+    check (risk_level in ('low', 'medium', 'high', 'critical', 'green', 'amber', 'red')),
+  responsible_team text not null,
+  required_decision text,
+  due_date date,
+  status text not null default 'open'
+    check (status in ('open', 'in_progress', 'waiting_decision', 'closed', 'cancelled')),
+  expected_impact text,
+  closed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.audit_events (
+  id uuid primary key default gen_random_uuid(),
+  entity_table text not null,
+  entity_id uuid,
+  event_type text not null,
+  event_summary text not null,
+  old_values jsonb,
+  new_values jsonb,
+  actor_name text,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.user_profiles (
+  id uuid primary key default gen_random_uuid(),
+  auth_user_id uuid unique,
+  full_name text not null,
+  email text,
+  department text,
+  role_name text not null default 'viewer',
+  is_active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.role_permissions (
+  id uuid primary key default gen_random_uuid(),
+  role_name text not null,
+  module_name text not null,
+  can_view boolean not null default true,
+  can_create boolean not null default false,
+  can_update boolean not null default false,
+  can_delete boolean not null default false,
+  can_approve boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_line_assignments_line_id on public.line_current_assignments(line_id);
+create index if not exists idx_line_assignments_order_id on public.line_current_assignments(order_id);
+create index if not exists idx_line_assignments_plan_id on public.line_current_assignments(plan_id);
+create index if not exists idx_line_assignments_customer_id on public.line_current_assignments(customer_id);
+create index if not exists idx_line_assignments_style_id on public.line_current_assignments(style_id);
+create index if not exists idx_hourly_production_order_id on public.hourly_production(order_id);
+create index if not exists idx_hourly_production_plan_id on public.hourly_production(plan_id);
+create index if not exists idx_hourly_production_line_id on public.hourly_production(line_id);
+create index if not exists idx_hourly_production_date on public.hourly_production(production_date);
+create index if not exists idx_downtime_events_line_id on public.downtime_events(line_id);
+create index if not exists idx_downtime_events_order_id on public.downtime_events(order_id);
+create index if not exists idx_downtime_events_plan_id on public.downtime_events(plan_id);
+create index if not exists idx_manpower_logs_line_id on public.manpower_logs(line_id);
+create index if not exists idx_manpower_logs_order_id on public.manpower_logs(order_id);
+create index if not exists idx_quality_records_order_id on public.quality_records(order_id);
+create index if not exists idx_quality_records_stage_record_id on public.quality_records(stage_record_id);
+create index if not exists idx_management_actions_order_id on public.management_actions(order_id);
+create index if not exists idx_audit_events_entity on public.audit_events(entity_table, entity_id);
+
+alter table public.line_current_assignments enable row level security;
+alter table public.hourly_production enable row level security;
+alter table public.downtime_events enable row level security;
+alter table public.manpower_logs enable row level security;
+alter table public.quality_records enable row level security;
+alter table public.management_actions enable row level security;
+alter table public.audit_events enable row level security;
+alter table public.user_profiles enable row level security;
+alter table public.role_permissions enable row level security;

--- a/supabase/migrations/003_authenticated_development_rls_policies.sql
+++ b/supabase/migrations/003_authenticated_development_rls_policies.sql
@@ -1,0 +1,58 @@
+-- V1 development policies for the existing Jade Textile public tables.
+-- These policies intentionally allow any authenticated user to read and write
+-- during the foundation phase. Tighten these before exposing production data.
+
+grant usage on schema public to authenticated;
+
+do $$
+declare
+  app_tables text[] := array[
+    'customers',
+    'production_groups',
+    'factory_lines',
+    'style_master',
+    'orders',
+    'material_readiness',
+    'production_plans',
+    'production_stage_records',
+    'factory_snapshots',
+    'app_settings',
+    'line_current_assignments',
+    'hourly_production',
+    'downtime_events',
+    'manpower_logs',
+    'quality_records',
+    'management_actions',
+    'audit_events',
+    'user_profiles',
+    'role_permissions'
+  ];
+  table_name text;
+begin
+  foreach table_name in array app_tables loop
+    execute format('alter table public.%I enable row level security', table_name);
+    execute format('grant select, insert, update, delete on public.%I to authenticated', table_name);
+
+    execute format(
+      'drop policy if exists %I on public.%I',
+      'authenticated read ' || table_name,
+      table_name
+    );
+    execute format(
+      'create policy %I on public.%I for select to authenticated using (true)',
+      'authenticated read ' || table_name,
+      table_name
+    );
+
+    execute format(
+      'drop policy if exists %I on public.%I',
+      'authenticated write ' || table_name,
+      table_name
+    );
+    execute format(
+      'create policy %I on public.%I for all to authenticated using (true) with check (true)',
+      'authenticated write ' || table_name,
+      table_name
+    );
+  end loop;
+end $$;

--- a/supabase/seeds/001_customers_lines_seed.sql
+++ b/supabase/seeds/001_customers_lines_seed.sql
@@ -1,0 +1,78 @@
+begin;
+
+insert into public.customers (customer_code, customer_name, customer_group, status)
+values
+  ('JADE', 'Jade Export', 'Internal priority', 'active'),
+  ('NORTH', 'North Retail', 'Export retail', 'active')
+on conflict (customer_code) do update
+set
+  customer_name = excluded.customer_name,
+  customer_group = excluded.customer_group,
+  status = excluded.status,
+  updated_at = now();
+
+insert into public.production_groups (group_code, group_name, is_active, notes)
+values
+  ('H', 'Group H', true, 'Core sewing production group.'),
+  ('G', 'Group G', true, 'Core sewing production group.'),
+  ('GHOST', 'Ghost / Non-working', false, 'Non-working lines retained for historical accuracy.')
+on conflict (group_code) do update
+set
+  group_name = excluded.group_name,
+  is_active = excluded.is_active,
+  notes = excluded.notes,
+  updated_at = now();
+
+insert into public.factory_lines (
+  line_code,
+  zone,
+  floor,
+  line_type,
+  is_active,
+  is_core_production,
+  group_id,
+  notes
+)
+values
+  (
+    'H93',
+    'H Zone',
+    'Main Floor',
+    'production',
+    true,
+    true,
+    (select id from public.production_groups where group_code = 'H'),
+    'Legacy H93/115 label is normalized to H93. Do not create H115.'
+  ),
+  (
+    'G-14',
+    'G Zone',
+    'Main Floor',
+    'production',
+    true,
+    true,
+    (select id from public.production_groups where group_code = 'G'),
+    'G-14 correction preserved.'
+  ),
+  (
+    'G-11',
+    'Ghost / Non-working',
+    'Main Floor',
+    'ghost',
+    false,
+    false,
+    (select id from public.production_groups where group_code = 'GHOST'),
+    'Ghost/non-working line retained so historical references remain traceable.'
+  )
+on conflict (line_code) do update
+set
+  zone = excluded.zone,
+  floor = excluded.floor,
+  line_type = excluded.line_type,
+  is_active = excluded.is_active,
+  is_core_production = excluded.is_core_production,
+  group_id = excluded.group_id,
+  notes = excluded.notes,
+  updated_at = now();
+
+commit;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src", "vite.config.ts"]
+}


### PR DESCRIPTION
## Summary

Closes #1.

- Builds the first connected React + TypeScript app shell with Executive Command Center as the first screen and Sewing Control Room as the second screen.
- Isolates Supabase setup in `src/lib/supabase.ts`, uses `VITE_SUPABASE_URL` and `VITE_SUPABASE_PUBLISHABLE_KEY`, and falls back to mock data only when env values are missing.
- Centralizes factory formulas and risk/line-code rules, including H93 normalization, G-14 preservation, and G-11 ghost/non-working detection across line, group, zone, line type, and active/core-production flags.
- Updates Sewing Control Room to select today's assignment when available, otherwise the latest assignment per line, instead of using the first embedded assignment row.
- Adds GitHub Actions CI for `npm install`, `npm run lint`, and `npm run build`.
- Adds V1 authenticated development RLS policies for the existing Supabase tables without inventing database tables.

## Verification

- `npm install`
- `npm run lint`
- `npm run build`
- Supabase migration dry-run in a transaction, then rolled back

## Notes

Real Supabase keys are not committed. The UI reads the live project tables when configured and remains safe when env values are absent.